### PR TITLE
Image Fixes/Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ bsky.create_reply(post_uri, "Great post!", embed_images: ["path/to/image.jpg"])
 
 Images are automatically optimized:
 - Large images are automatically resized and compressed
-- Maximum size is enforced (900KB)
+- Maximum size is enforced (999KB)
 - Image quality is preserved while reducing file size
 - Supports both local files and remote URLs
 

--- a/lib/bskyrb/records.rb
+++ b/lib/bskyrb/records.rb
@@ -16,6 +16,7 @@ module Bskyrb
     def initialize(session)
       @session = session
       @pds = session.credentials.pds
+      @img_compression = ENV.fetch("BSKYRB_IMG_COMPRESSION", "100")
     end
 
     def create_record(input)
@@ -73,7 +74,7 @@ module Bskyrb
           image.resize "#{new_width}x#{new_height}"
 
           # Optionally, you can also compress the image
-          image.quality "85"  # Adjust quality as needed (0-100)
+          image.quality @img_compression  # Adjust quality as needed (0-100)
 
           # Save the modified image to a temporary file
           temp_file = "#{blob_path}.tmp"

--- a/lib/bskyrb/records.rb
+++ b/lib/bskyrb/records.rb
@@ -56,7 +56,8 @@ module Bskyrb
     def upload_blob(blob_path, content_type)
       if content_type.include?("image")
         # only images
-        max_size = 900 * 1024  # 900KB in bytes
+        # https://github.com/bluesky-social/atproto/blob/72a5265e05d8eec4f10acdae8f6dfee409ea820a/lexicons/app/bsky/embed/images.json#L24
+        max_size = 999 * 1024  # 999KB in bytes
         file_size = File.size(blob_path)
 
         if file_size > max_size


### PR DESCRIPTION
Hey! 👋 

I wanted to pop open a quick PR for some fixes to the image aspects of this library that I thought would help. Images on BlueSky can be a [max of 1MB](https://github.com/bluesky-social/atproto/blob/72a5265e05d8eec4f10acdae8f6dfee409ea820a/lexicons/app/bsky/embed/images.json#L24) so I thought it made sense to bump the values seen in this library to be _just shy_ of that value (to 999KB).

I also wanted to have images upload at 100% quality by default so I made that into an environment variable to control it.